### PR TITLE
Improve column form reuse and quick task UX

### DIFF
--- a/frontend/src/components/ColumnForm.tsx
+++ b/frontend/src/components/ColumnForm.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+type ColumnFormProps = {
+  title: string;
+  error?: string | null;
+  busy?: boolean;
+  className?: string;
+  footerClassName?: string;
+  headingClassName?: string;
+  onTitleChange: (value: string) => void;
+  onCancel: () => void;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+};
+
+export const ColumnForm: React.FC<ColumnFormProps> = ({
+  title,
+  error,
+  busy = false,
+  className = '',
+  footerClassName = '',
+  headingClassName = 'text-base',
+  onTitleChange,
+  onCancel,
+  onSubmit,
+}) => (
+  <form
+    onSubmit={onSubmit}
+    className={`flex flex-col gap-4 rounded-2xl border border-dashed border-indigo-300 bg-white/80 text-sm shadow-sm ${className}`}
+  >
+    <div className="space-y-3">
+      <h2 className={`${headingClassName} font-semibold text-indigo-700`}>Nueva columna</h2>
+      <input
+        value={title}
+        onChange={event => onTitleChange(event.target.value)}
+        autoFocus
+        placeholder="Nombre de la columna"
+        className="w-full rounded-lg border border-indigo-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+        disabled={busy}
+      />
+      {error && (
+        <p className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-600">{error}</p>
+      )}
+    </div>
+    <div className={`flex items-center justify-end gap-2 text-sm ${footerClassName}`}>
+      <button
+        type="button"
+        onClick={onCancel}
+        className="rounded-md px-3 py-1 font-medium text-slate-500 transition hover:text-slate-700"
+        disabled={busy}
+      >
+        Cancelar
+      </button>
+      <button
+        type="submit"
+        disabled={busy || !title.trim()}
+        className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3 py-1 font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:bg-indigo-200"
+      >
+        Crear
+      </button>
+    </div>
+  </form>
+);
+

--- a/frontend/src/dnd/utils.ts
+++ b/frontend/src/dnd/utils.ts
@@ -11,7 +11,7 @@ export const rawId = (id: DndId) => id.split(':')[1];
 
 export function computeNewPosition(
   destListLength: number,
-  destIndex: number,
+  _destIndex: number,
   before?: number,
   after?: number
 ): number {

--- a/frontend/src/hooks/useRealtimeBoard.ts
+++ b/frontend/src/hooks/useRealtimeBoard.ts
@@ -54,6 +54,7 @@ export function useRealtimeBoard(options: UseRealtimeBoardOptions | string) {
 
     return () => {
       if (boardId) {
+        socket.emit('leaveBoard', { boardId });
         socket.off('task.created', onTaskCreated);
         socket.off('task.updated', onTaskUpdated);
         socket.off('task.moved', onTaskMoved);


### PR DESCRIPTION
## Summary
- extract a reusable column creation form and reuse it in both board layouts
- add optimistic quick-task creation with error handling and disable the action while pending
- emit `leaveBoard` when unmounting realtime subscriptions and silence an unused parameter warning

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e4b078b2248333854693e37d084cde