### PR TITLE
Align backlog export with n8n workflow

### DIFF
--- a/backend/api-kanban/src/exports/dto/report-status.dto.ts
+++ b/backend/api-kanban/src/exports/dto/report-status.dto.ts
@@ -1,4 +1,14 @@
-import { ArrayNotEmpty, ArrayUnique, IsArray, IsEmail, IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {
+  ArrayNotEmpty,
+  ArrayUnique,
+  IsArray,
+  IsEmail,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateIf,
+} from 'class-validator';
 import { ExportField } from './request-export.dto';
 
 export enum ExportFinalStatus {
@@ -18,9 +28,13 @@ export class ReportStatusDto {
   @IsEnum(ExportFinalStatus)
   status!: ExportFinalStatus;
 
-  @IsOptional()
+  @ValidateIf(dto => !dto.to)
   @IsEmail()
   email?: string;
+
+  @ValidateIf(dto => !dto.email)
+  @IsEmail()
+  to?: string;
 
   @IsOptional()
   @IsArray()

--- a/backend/api-kanban/src/exports/dto/request-export.dto.ts
+++ b/backend/api-kanban/src/exports/dto/request-export.dto.ts
@@ -1,4 +1,14 @@
-import { ArrayNotEmpty, ArrayUnique, IsArray, IsEmail, IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {
+  ArrayNotEmpty,
+  ArrayUnique,
+  IsArray,
+  IsEmail,
+  IsIn,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateIf,
+} from 'class-validator';
 
 export const EXPORTABLE_FIELDS = ['id', 'title', 'description', 'column', 'createdAt'] as const;
 export type ExportField = (typeof EXPORTABLE_FIELDS)[number];
@@ -8,8 +18,13 @@ export class RequestExportDto {
   @IsNotEmpty()
   boardId!: string;
 
+  @ValidateIf(dto => !dto.email)
   @IsEmail()
-  email!: string;
+  to?: string;
+
+  @ValidateIf(dto => !dto.to)
+  @IsEmail()
+  email?: string;
 
   @IsOptional()
   @IsArray()

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -42,7 +42,7 @@ export const TasksAPI = {
 };
 
 export const ExportAPI = {
-  requestBacklog: (payload: { boardId: string; email: string; fields?: ExportField[] }) =>
+  requestBacklog: (payload: { boardId: string; to: string; fields?: ExportField[] }) =>
     http.post<ExportRecord>('/export/backlog', payload).then(r => r.data),
   status: (requestId: string) =>
     http.get<ExportRecord>(`/export/backlog/${requestId}`).then(r => r.data),

--- a/frontend/src/components/BoardPage.tsx
+++ b/frontend/src/components/BoardPage.tsx
@@ -113,7 +113,7 @@ export const BoardPage: React.FC<BoardPageProps> = ({ board, onBack, onBoardUpda
       setLastExport(current => (current && current.requestId === payload.requestId ? { ...current, ...payload } : payload));
       setExportNotice({
         type: 'info',
-        message: `Exportación solicitada. Enviaremos el CSV a ${payload.email}.`,
+        message: `Exportación solicitada. Enviaremos el CSV a ${payload.to}.`,
       });
     },
     [boardId],
@@ -125,7 +125,7 @@ export const BoardPage: React.FC<BoardPageProps> = ({ board, onBack, onBoardUpda
       setLastExport(payload);
       setExportNotice({
         type: 'success',
-        message: `Exportación completada. Revisa tu correo (${payload.email}).`,
+        message: `Exportación completada. Revisa tu correo (${payload.to}).`,
       });
     },
     [boardId],
@@ -376,13 +376,13 @@ export const BoardPage: React.FC<BoardPageProps> = ({ board, onBack, onBoardUpda
     try {
       const response = await ExportAPI.requestBacklog({
         boardId,
-        email: cleanEmail,
+        to: cleanEmail,
         fields: selectedFields,
       });
       setLastExport(response);
       setExportNotice({
         type: 'info',
-        message: `Exportación solicitada. Enviaremos el CSV a ${response.email}.`,
+        message: `Exportación solicitada. Enviaremos el CSV a ${response.to}.`,
       });
       setShowExportPanel(false);
     } catch (err) {

--- a/frontend/src/types/export.ts
+++ b/frontend/src/types/export.ts
@@ -5,7 +5,7 @@ export type ExportStatusValue = 'pending' | 'success' | 'error';
 export type ExportRecord = {
   requestId: string;
   boardId: string;
-  email: string;
+  to: string;
   fields: ExportField[];
   status: ExportStatusValue;
   requestedAt: string;


### PR DESCRIPTION
## Summary
- update the NestJS export DTOs and service to accept a `to` field, enforce a recipient, and forward it to the n8n webhook while keeping realtime updates consistent
- allow status callbacks to refresh the stored recipient and keep `to` in the serialized payloads consumed by the frontend
- adjust the frontend API client, types, and export UI copy to post the `to` field and show the destination address from responses/events

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e602cf221483339e08b290c12de3a4