### PR TITLE
Align backlog export with n8n workflow

### DIFF
--- a/backend/api-kanban/src/exports/dto/report-status.dto.ts
+++ b/backend/api-kanban/src/exports/dto/report-status.dto.ts
@@ -1,4 +1,14 @@
-import { ArrayNotEmpty, ArrayUnique, IsArray, IsEmail, IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {
+  ArrayNotEmpty,
+  ArrayUnique,
+  IsArray,
+  IsEmail,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateIf,
+} from 'class-validator';
 import { ExportField } from './request-export.dto';
 
 export enum ExportFinalStatus {
@@ -18,9 +28,13 @@ export class ReportStatusDto {
   @IsEnum(ExportFinalStatus)
   status!: ExportFinalStatus;
 
-  @IsOptional()
+  @ValidateIf(dto => !dto.to)
   @IsEmail()
   email?: string;
+
+  @ValidateIf(dto => !dto.email)
+  @IsEmail()
+  to?: string;
 
   @IsOptional()
   @IsArray()

--- a/backend/api-kanban/src/exports/dto/request-export.dto.ts
+++ b/backend/api-kanban/src/exports/dto/request-export.dto.ts
@@ -1,4 +1,14 @@
-import { ArrayNotEmpty, ArrayUnique, IsArray, IsEmail, IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {
+  ArrayNotEmpty,
+  ArrayUnique,
+  IsArray,
+  IsEmail,
+  IsIn,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateIf,
+} from 'class-validator';
 
 export const EXPORTABLE_FIELDS = ['id', 'title', 'description', 'column', 'createdAt'] as const;
 export type ExportField = (typeof EXPORTABLE_FIELDS)[number];
@@ -8,8 +18,13 @@ export class RequestExportDto {
   @IsNotEmpty()
   boardId!: string;
 
+  @ValidateIf(dto => !dto.email)
   @IsEmail()
-  email!: string;
+  to?: string;
+
+  @ValidateIf(dto => !dto.to)
+  @IsEmail()
+  email?: string;
 
   @IsOptional()
   @IsArray()

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -42,7 +42,7 @@ export const TasksAPI = {
 };
 
 export const ExportAPI = {
-  requestBacklog: (payload: { boardId: string; email: string; fields?: ExportField[] }) =>
+  requestBacklog: (payload: { boardId: string; to: string; fields?: ExportField[] }) =>
     http.post<ExportRecord>('/export/backlog', payload).then(r => r.data),
   status: (requestId: string) =>
     http.get<ExportRecord>(`/export/backlog/${requestId}`).then(r => r.data),

--- a/frontend/src/components/BoardPage.tsx
+++ b/frontend/src/components/BoardPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DndContext, DragOverlay, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
 import { SortableContext, horizontalListSortingStrategy } from '@dnd-kit/sortable';
@@ -84,6 +84,7 @@ export const BoardPage: React.FC<BoardPageProps> = ({ board, onBack, onBoardUpda
     | null
   >(null);
   const [lastExport, setLastExport] = useState<ExportRecord | null>(null);
+  const exportPollTimeout = useRef<number | null>(null);
 
   useEffect(() => {
     if (!isRenaming) {
@@ -113,7 +114,7 @@ export const BoardPage: React.FC<BoardPageProps> = ({ board, onBack, onBoardUpda
       setLastExport(current => (current && current.requestId === payload.requestId ? { ...current, ...payload } : payload));
       setExportNotice({
         type: 'info',
-        message: `Exportación solicitada. Enviaremos el CSV a ${payload.email}.`,
+        message: `Exportación solicitada. Enviaremos el CSV a ${payload.to}.`,
       });
     },
     [boardId],
@@ -125,7 +126,7 @@ export const BoardPage: React.FC<BoardPageProps> = ({ board, onBack, onBoardUpda
       setLastExport(payload);
       setExportNotice({
         type: 'success',
-        message: `Exportación completada. Revisa tu correo (${payload.email}).`,
+        message: `Exportación completada. Revisa tu correo (${payload.to}).`,
       });
     },
     [boardId],
@@ -153,6 +154,63 @@ export const BoardPage: React.FC<BoardPageProps> = ({ board, onBack, onBoardUpda
     onExportCompleted: handleExportCompleted,
     onExportFailed: handleExportFailed,
   });
+
+  const clearExportPolling = useCallback(() => {
+    if (exportPollTimeout.current !== null) {
+      window.clearTimeout(exportPollTimeout.current);
+      exportPollTimeout.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => clearExportPolling(), [clearExportPolling]);
+
+  const pendingExportId = lastExport?.requestId ?? null;
+  const pendingExportStatus = lastExport?.status ?? null;
+
+  useEffect(() => {
+    if (!pendingExportId || pendingExportStatus !== 'pending') {
+      clearExportPolling();
+      return;
+    }
+
+    let cancelled = false;
+
+    const pollStatus = async () => {
+      try {
+        const status = await ExportAPI.status(pendingExportId);
+        if (cancelled) return;
+        setLastExport(status);
+        if (status.status === 'pending') {
+          exportPollTimeout.current = window.setTimeout(pollStatus, 4000);
+          return;
+        }
+        if (status.status === 'success') {
+          setExportNotice({
+            type: 'success',
+            message: `Exportación completada. Revisa tu correo (${status.to}).`,
+          });
+        } else {
+          setExportNotice({
+            type: 'error',
+            message: status.error
+              ? `La exportación falló: ${status.error}`
+              : 'La exportación del backlog no pudo completarse.',
+          });
+        }
+      } catch (err) {
+        if (cancelled) return;
+        console.error('Polling export status failed', err);
+        exportPollTimeout.current = window.setTimeout(pollStatus, 6000);
+      }
+    };
+
+    exportPollTimeout.current = window.setTimeout(pollStatus, 4000);
+
+    return () => {
+      cancelled = true;
+      clearExportPolling();
+    };
+  }, [pendingExportId, pendingExportStatus, clearExportPolling]);
 
   useEffect(() => {
     let alive = true;
@@ -376,13 +434,13 @@ export const BoardPage: React.FC<BoardPageProps> = ({ board, onBack, onBoardUpda
     try {
       const response = await ExportAPI.requestBacklog({
         boardId,
-        email: cleanEmail,
+        to: cleanEmail,
         fields: selectedFields,
       });
       setLastExport(response);
       setExportNotice({
         type: 'info',
-        message: `Exportación solicitada. Enviaremos el CSV a ${response.email}.`,
+        message: `Exportación solicitada. Enviaremos el CSV a ${response.to}.`,
       });
       setShowExportPanel(false);
     } catch (err) {

--- a/frontend/src/types/export.ts
+++ b/frontend/src/types/export.ts
@@ -5,7 +5,7 @@ export type ExportStatusValue = 'pending' | 'success' | 'error';
 export type ExportRecord = {
   requestId: string;
   boardId: string;
-  email: string;
+  to: string;
   fields: ExportField[];
   status: ExportStatusValue;
   requestedAt: string;


### PR DESCRIPTION
## Summary
- update the NestJS export DTOs and service to accept a `to` field, enforce a recipient, and forward it to the n8n webhook while keeping realtime updates consistent
- allow status callbacks to refresh the stored recipient and keep `to` in the serialized payloads consumed by the frontend
- adjust the frontend API client, types, and export UI copy to post the `to` field and show the destination address from responses/events
- add a frontend polling fallback so the backlog export notice switches to success or error even if the realtime event is missed