### PR TITLE
Add callback reporting to export workflow

### DIFF
--- a/n8n/workflow.json
+++ b/n8n/workflow.json
@@ -53,7 +53,8 @@
           "id": "Ri4SkOnKvIyRCNF0",
           "name": "SMTP account"
         }
-      }
+      },
+      "continueOnFail": true
     },
     {
       "parameters": {
@@ -130,6 +131,39 @@
       ],
       "id": "8ae50716-e52a-40ec-b97f-b3a539e26406",
       "name": "Split Out"
+    },
+    {
+      "parameters": {
+        "jsCode": "const webhook = ($node['Webhook (Export Backlog)'].json?.body ?? {});\nconst transformed = ($node['Code'].item?.json ?? {});\nconst current = $json ?? {};\n\nconst firstError = current.error ?? current.message ?? current.description ?? current.errorMessage;\nlet errorMessage = null;\nif (firstError) {\n  if (typeof firstError === 'string') {\n    errorMessage = firstError;\n  } else if (typeof firstError.message === 'string') {\n    errorMessage = firstError.message;\n  } else if (typeof firstError.description === 'string') {\n    errorMessage = firstError.description;\n  } else if (typeof firstError.data === 'string') {\n    errorMessage = firstError.data;\n  } else if (firstError.data?.message) {\n    errorMessage = firstError.data.message;\n  } else {\n    try {\n      errorMessage = JSON.stringify(firstError);\n    } catch (error) {\n      errorMessage = 'Error desconocido al enviar el correo.';\n    }\n  }\n}\n\nconst callbackUrl = transformed.callbackUrl ?? webhook.callbackUrl;\nif (!callbackUrl) {\n  throw new Error('No se recibió callbackUrl desde el webhook de exportación.');\n}\n\nconst requestId = transformed.requestId ?? webhook.requestId;\nconst boardId = transformed.boardId ?? webhook.boardId ?? webhook.board?.id;\nconst recipient = transformed.to ?? webhook.to ?? webhook.email ?? '';\nconst email = webhook.email ?? transformed.email ?? recipient;\nconst fields = Array.isArray(transformed.fields) && transformed.fields.length\n  ? transformed.fields\n  : Array.isArray(webhook.fields) && webhook.fields.length\n    ? webhook.fields\n    : [];\n\nconst payload = {\n  requestId,\n  boardId,\n  status: errorMessage ? 'error' : 'success',\n  to: recipient,\n  email,\n};\n\nif (fields.length) {\n  payload.fields = fields;\n}\nif (errorMessage) {\n  payload.error = errorMessage;\n}\n\nconst headers = {};\nconst statusToken = transformed.statusToken ?? webhook.statusToken ?? webhook.exportStatusToken;\nif (statusToken) {\n  headers['x-export-token'] = statusToken;\n}\n\nreturn [{ json: { callbackUrl, payload: JSON.stringify(payload), headers } }];\n"
+      },
+      "id": "ac3a6b5e-1e2c-4b2e-9a9b-0fcb45d1f0f1",
+      "name": "Prepare Callback",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1600,
+        40
+      ]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "url": "={{ $json.callbackUrl }}",
+        "jsonParameters": true,
+        "bodyParametersJson": "={{ $json.payload }}",
+        "options": {
+          "bodyContentType": "json"
+        },
+        "headerParametersJson": "={{ $json.headers ?? {} }}"
+      },
+      "id": "3e9f7c54-6cbf-4e7b-9e2e-4da46c474f2a",
+      "name": "Report Status",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [
+        1820,
+        40
+      ]
     }
   ],
   "pinData": {},
@@ -207,7 +241,13 @@
     },
     "Send Email": {
       "main": [
-        []
+        [
+          {
+            "node": "Prepare Callback",
+            "type": "main",
+            "index": 0
+          }
+        ]
       ]
     },
     "Split Out": {
@@ -219,6 +259,22 @@
             "index": 0
           }
         ]
+      ]
+    },
+    "Prepare Callback": {
+      "main": [
+        [
+          {
+            "node": "Report Status",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Report Status": {
+      "main": [
+        []
       ]
     }
   },


### PR DESCRIPTION
## Summary
- ensure the Send Email node continues on failure so the flow can always report status back to the backend
- add a callback-preparation step that builds the payload with request metadata and potential errors
- send the prepared payload to the backend callback URL to mark the export as success or error