### PR TITLE
Add n8n workflow documentation and docker compose setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Backend API
+PORT=3000
+MONGODB_URI=mongodb://localhost:27017/kanban
+
+# Frontend (Vite)
+VITE_API_URL=http://localhost:3000/api
+VITE_API_WS=http://localhost:3000/ws
+
+# n8n workflow integration
+KANBAN_API_URL=http://host.docker.internal:3000/api
+N8N_PORT=5678
+N8N_HOST=0.0.0.0
+N8N_BASIC_AUTH_ACTIVE=true
+N8N_BASIC_AUTH_USER=admin
+N8N_BASIC_AUTH_PASSWORD=change-me
+N8N_EMAIL_FROM=automations@example.com
+N8N_MONGODB_URL=mongodb://mongo:27017/n8n
+N8N_ENCRYPTION_KEY=generate-a-long-secure-string

--- a/README.md
+++ b/README.md
@@ -1,0 +1,76 @@
+# Tablero Kanban
+
+Este repositorio contiene el backend (NestJS), frontend (Vite + Svelte) y las automatizaciones de n8n para el tablero Kanban utilizado en la prueba técnica.
+
+## Requisitos
+
+- Node.js 18+
+- pnpm o npm (el proyecto incluye `package-lock.json`, por lo que se recomienda `npm`)
+- Docker y Docker Compose (para ejecutar n8n y MongoDB desde contenedores)
+
+## Configuración inicial
+
+1. Duplica el archivo `.env.example` y renómbralo como `.env`.
+2. Ajusta las variables para que apunten a tus servicios locales o remotos.
+3. Instala las dependencias del backend y frontend:
+
+```bash
+cd backend/api-kanban
+npm install
+
+cd ../../frontend
+npm install
+```
+
+## Ejecutar el backend (API)
+
+```bash
+cd backend/api-kanban
+npm run start:dev
+```
+
+La API se expone en `http://localhost:3000/api` por defecto y requiere una instancia de MongoDB accesible mediante `MONGODB_URI`.
+
+## Ejecutar el frontend
+
+```bash
+cd frontend
+npm run dev
+```
+
+Por defecto la interfaz se servirá en `http://localhost:5173` y consumirá la API definida en `VITE_API_URL`.
+
+## Automatización en n8n
+
+En la raíz del repositorio se incluye un `docker-compose.yml` que levanta MongoDB y n8n con la versión `1.106.3`. Para ejecutarlo:
+
+```bash
+docker compose up -d
+```
+
+Una vez que n8n esté en ejecución visita `http://localhost:5678` y sigue las instrucciones detalladas en [`n8n/setup-instructions.md`](n8n/setup-instructions.md) para importar y activar el workflow ubicado en `n8n/workflow.json`.
+
+## Variables de entorno relevantes
+
+| Variable | Descripción |
+|----------|-------------|
+| `PORT` | Puerto donde se expone la API de NestJS. |
+| `MONGODB_URI` | Cadena de conexión utilizada por la API. |
+| `VITE_API_URL` | URL base para las peticiones HTTP del frontend. |
+| `VITE_API_WS` | Endpoint del WebSocket usado para actualizaciones en tiempo real. |
+| `KANBAN_API_URL` | URL base que utiliza n8n para consultar la API. |
+| `N8N_*` | Parámetros de autenticación y configuración de n8n. |
+
+## Pruebas del workflow
+
+Envía una petición POST a la URL del webhook que n8n genere (ej. `http://localhost:5678/webhook/export-backlog`) con un payload como:
+
+```json
+{
+  "boardId": "663fa901c72f901d48b78910",
+  "to": "usuario@dominio.com",
+  "fields": ["id", "title", "description", "column", "createdAt"]
+}
+```
+
+El flujo descargará el backlog desde la API, generará un CSV y lo enviará como adjunto al correo especificado.

--- a/backend/api-kanban/src/tasks/tasks.service.ts
+++ b/backend/api-kanban/src/tasks/tasks.service.ts
@@ -33,6 +33,9 @@ export class TasksService {
 
   move(id: string, dto: MoveTaskDto) {
     return this.model.findByIdAndUpdate(id, dto, { new: true }).then(doc => {
+      // La notificación en tiempo real mantiene sincronizados a todos los clientes
+      // conectados al tablero enviando el evento del movimiento únicamente si la
+      // actualización fue exitosa.
       if (doc) this.events.emitToBoard(String(doc.boardId), RealtimeEvents.TaskMoved, doc);
       return doc;
     });
@@ -40,6 +43,8 @@ export class TasksService {
 
   remove(id: string) {
     return this.model.findByIdAndDelete(id).then(doc => {
+      // Emitimos la eliminación para que cada cliente pueda retirar el task del
+      // tablero sin necesidad de refrescar la página ni volver a consultar la API.
       if (doc) this.events.emitToBoard(String(doc.boardId), RealtimeEvents.TaskDeleted, { id, columnId: doc.columnId });
       return doc;
     });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3.9'
+
+services:
+  mongo:
+    image: mongo:6
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_DATABASE: kanban
+    volumes:
+      - mongo_data:/data/db
+    networks:
+      - kanban-net
+
+  n8n:
+    image: n8nio/n8n:1.106.3
+    restart: unless-stopped
+    depends_on:
+      - mongo
+    env_file:
+      - .env
+    environment:
+      - DB_TYPE=mongodb
+      - DB_MONGODB_CONNECTION_URL=${N8N_MONGODB_URL:-mongodb://mongo:27017/n8n}
+      - N8N_PORT=${N8N_PORT:-5678}
+      - N8N_HOST=${N8N_HOST:-0.0.0.0}
+      - N8N_BASIC_AUTH_ACTIVE=${N8N_BASIC_AUTH_ACTIVE:-true}
+      - N8N_BASIC_AUTH_USER=${N8N_BASIC_AUTH_USER:-admin}
+      - N8N_BASIC_AUTH_PASSWORD=${N8N_BASIC_AUTH_PASSWORD:-change-me}
+      - N8N_ENCRYPTION_KEY=${N8N_ENCRYPTION_KEY}
+    ports:
+      - "${N8N_PORT:-5678}:5678"
+    volumes:
+      - n8n_data:/home/node/.n8n
+    networks:
+      - kanban-net
+
+networks:
+  kanban-net:
+    driver: bridge
+
+volumes:
+  mongo_data:
+  n8n_data:

--- a/n8n/setup-instructions.md
+++ b/n8n/setup-instructions.md
@@ -1,0 +1,65 @@
+# Configuración del flujo de exportación en n8n
+
+Estas instrucciones describen cómo ejecutar el flujo definido en `workflow.json` para automatizar la exportación del backlog del tablero Kanban y su envío por correo electrónico.
+
+## 1. Prerrequisitos
+
+- Docker y Docker Compose instalados.
+- Acceso a las credenciales SMTP que utilizará n8n para enviar correos.
+- La API del tablero Kanban corriendo y accesible desde la red donde se ejecute n8n.
+
+## 2. Preparar el archivo de entorno
+
+1. Duplica `.env.example` en la raíz del repositorio y renómbralo a `.env`.
+2. Actualiza los valores para que coincidan con tu entorno:
+   - `KANBAN_API_URL` debe apuntar al endpoint público de la API (incluye el prefijo `/api`).
+   - Define credenciales seguras para `N8N_BASIC_AUTH_*` y un valor aleatorio largo para `N8N_ENCRYPTION_KEY`.
+   - Establece `N8N_EMAIL_FROM` con la dirección que se usará como remitente en los correos.
+
+## 3. Levantar la infraestructura
+
+1. Ejecuta `docker compose up -d` en la raíz del proyecto para iniciar MongoDB y n8n.
+2. Accede a `http://localhost:5678` (o el puerto configurado en `N8N_PORT`).
+3. Inicia sesión con las credenciales definidas mediante `N8N_BASIC_AUTH_USER` y `N8N_BASIC_AUTH_PASSWORD`.
+
+## 4. Configurar credenciales SMTP en n8n
+
+1. Dentro de n8n, abre la sección **Credentials**.
+2. Crea una credencial de tipo **SMTP** llamada `SMTP account` (debe coincidir con el nombre referenciado por el workflow).
+3. Introduce el host, puerto, usuario y contraseña proporcionados por tu servicio de correo.
+4. Guarda la credencial.
+
+## 5. Importar y activar el workflow
+
+1. Desde el panel principal de n8n selecciona **Workflows → Import from File**.
+2. Carga el archivo `n8n/workflow.json` incluido en este repositorio.
+3. Verifica que cada nodo esté correctamente conectado:
+   - `Webhook (Export Backlog)` recibe las peticiones POST.
+   - Los nodos `Tasks` y `Columns` consultan la API usando `KANBAN_API_URL`.
+   - El nodo `Code` procesa las tareas y genera el dataset CSV.
+   - `Convert to File (CSV)` y `Send Email` adjuntan y envían el reporte.
+4. Activa el workflow y copia la URL del webhook que n8n mostrará. Debería tener la forma `https://<host>/webhook/export-backlog`.
+
+## 6. Probar la automatización
+
+Puedes probar la automatización enviando una petición POST al webhook con un payload similar al siguiente:
+
+```json
+{
+  "boardId": "<ID del tablero>",
+  "to": "destinatario@dominio.com",
+  "fields": ["id", "title", "description", "column", "createdAt"]
+}
+```
+
+El workflow realizará estas acciones:
+
+1. Recuperará todas las tareas y columnas desde la API de Kanban usando el ID del tablero.
+2. Construirá un CSV ordenado por columnas y lo convertirá en un archivo.
+3. Enviará el correo al destinatario con el archivo adjunto.
+
+Si necesitas depurar el flujo, ejecuta los nodos de manera manual en el editor de n8n y revisa la pestaña **Execution data** para inspeccionar la salida de cada paso.
+
+## 7. Apagar los servicios
+
+Cuando termines, ejecuta `docker compose down` para detener los contenedores. Si deseas eliminar los volúmenes (incluyendo datos de n8n y MongoDB), añade la opción `-v` al comando.

--- a/n8n/workflow.json
+++ b/n8n/workflow.json
@@ -32,7 +32,7 @@
     },
     {
       "parameters": {
-        "fromEmail": "santhenao4@gmail.com",
+        "fromEmail": "={{ $env.N8N_EMAIL_FROM }}",
         "toEmail": "={{ $('Code').item.json.to }}",
         "subject": "=Exportación backlog – Board {{ $('Code').item.json.boardId }}",
         "text": "Adjunto encontrarás el CSV exportado del tablero.\n",
@@ -71,7 +71,7 @@
     },
     {
       "parameters": {
-        "url": "=http://host.docker.internal:3000/api/tasks/board/{{$json.body.boardId}}\n",
+        "url": "={{ $env.KANBAN_API_URL ?? 'http://host.docker.internal:3000/api' }}/tasks/board/{{$json.body.boardId}}",
         "options": {
           "redirect": {
             "redirect": {}
@@ -90,7 +90,7 @@
     },
     {
       "parameters": {
-        "url": "=http://host.docker.internal:3000/api/columns/board/{{$json.body.boardId}}",
+        "url": "={{ $env.KANBAN_API_URL ?? 'http://host.docker.internal:3000/api' }}/columns/board/{{$json.body.boardId}}",
         "options": {
           "redirect": {
             "redirect": {}


### PR DESCRIPTION
## Summary
- add a root README and .env example covering the backend, frontend, and n8n variables
- provide docker-compose orchestration for MongoDB and n8n 1.106.3 plus a detailed setup guide
- parameterize the workflow HTTP requests and email sender via environment variables and explain realtime notifications in code

## Testing
- not run (documentation and configuration changes only)


------
https://chatgpt.com/codex/tasks/task_b_68e6a1caa2a88333becd6ed42223c7ba